### PR TITLE
Feature/ubr 144

### DIFF
--- a/src/Exception/IncorrectParameterValueException.php
+++ b/src/Exception/IncorrectParameterValueException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CultuurNet\UiTPASBeheer\Exception;
+
+class IncorrectParameterValueException extends ReadableCodeResponseException
+{
+    public function __construct($parameter, $code = 'INCORRECT_PARAMETER_VALUE')
+    {
+        $message = sprintf(
+            'Incorrect value for parameter "%s".', $parameter);
+        parent::__construct($message, $code);
+    }
+}

--- a/src/Exception/IncorrectParameterValueException.php
+++ b/src/Exception/IncorrectParameterValueException.php
@@ -6,8 +6,7 @@ class IncorrectParameterValueException extends ReadableCodeResponseException
 {
     public function __construct($parameter, $code = 'INCORRECT_PARAMETER_VALUE')
     {
-        $message = sprintf(
-            'Incorrect value for parameter "%s".', $parameter);
+        $message = sprintf('Incorrect value for parameter "%s".', $parameter);
         parent::__construct($message, $code);
     }
 }

--- a/src/UiTPAS/UiTPASController.php
+++ b/src/UiTPAS/UiTPASController.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UiTPASBeheer\UiTPAS;
 
 use CultuurNet\UiTPASBeheer\Exception\MissingParameterException;
+use CultuurNet\UiTPASBeheer\Exception\IncorrectParameterValueException;
 use CultuurNet\UiTPASBeheer\Exception\UnknownParameterException;
 use CultuurNet\UiTPASBeheer\PassHolder\VoucherNumber;
 use CultuurNet\UiTPASBeheer\UiTPAS\Price\Inquiry;
@@ -107,10 +108,13 @@ class UiTPASController
                     break;
 
                 case 'date_of_birth':
+                    $datetime = \DateTime::createFromFormat('Y-m-d', $value);
+                    if (!$datetime) {
+                        throw new IncorrectParameterValueException('date_of_birth');
+                    }
+
                     $inquiry = $inquiry->withDateOfBirth(
-                        Date::fromNativeDateTime(
-                            \DateTime::createFromFormat('Y-m-d', $value)
-                        )
+                        Date::fromNativeDateTime($datetime)
                     );
                     break;
 

--- a/test/UiTPAS/UiTPASControllerTest.php
+++ b/test/UiTPAS/UiTPASControllerTest.php
@@ -5,6 +5,7 @@ namespace CultuurNet\UiTPASBeheer\UiTPAS;
 use CultuurNet\UiTPASBeheer\CardSystem\CardSystem;
 use CultuurNet\UiTPASBeheer\CardSystem\Properties\CardSystemId;
 use CultuurNet\UiTPASBeheer\Exception\MissingParameterException;
+use CultuurNet\UiTPASBeheer\Exception\IncorrectParameterValueException;
 use CultuurNet\UiTPASBeheer\Exception\UnknownParameterException;
 use CultuurNet\UiTPASBeheer\JsonAssertionTrait;
 use CultuurNet\UiTPASBeheer\KansenStatuut\KansenStatuutJsonDeserializer;
@@ -218,6 +219,23 @@ class UiTPASControllerTest extends \PHPUnit_Framework_TestCase
                 [
                     'reason' => 'FIRST_CARD',
                     'foo' => 'bar',
+                ]
+            ),
+            '0930000420206'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_when_date_of_birth_parameter_is_invalid()
+    {
+        $this->setExpectedException(IncorrectParameterValueException::class);
+        $this->controller->getPrice(
+            new Request(
+                [
+                    'reason' => 'FIRST_CARD',
+                    'date_of_birth' => 'x'
                 ]
             ),
             '0930000420206'

--- a/test/UiTPAS/UiTPASControllerTest.php
+++ b/test/UiTPAS/UiTPASControllerTest.php
@@ -235,7 +235,7 @@ class UiTPASControllerTest extends \PHPUnit_Framework_TestCase
             new Request(
                 [
                     'reason' => 'FIRST_CARD',
-                    'date_of_birth' => 'x'
+                    'date_of_birth' => 'x',
                 ]
             ),
             '0930000420206'


### PR DESCRIPTION
An incorrect date_of_birth parameter causes a fatal error, IncorrectParameterValueException can be used for other kinds of parameters as well.