### PR TITLE
UPS-2981: allow empty date_type parameter to fetch all results.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-- 5.5
 - 5.6
 - 7.0
 install:

--- a/src/Activity/ActivityController.php
+++ b/src/Activity/ActivityController.php
@@ -65,13 +65,16 @@ class ActivityController
         foreach ($request->query->all() as $parameter => $value) {
             switch ($parameter) {
                 case 'date_type':
-                    try {
-                        $searchActivities = $searchActivities->withDateType(
-                            DateType::fromNative($value)
-                        );
-                    } catch (\InvalidArgumentException $e) {
-                        throw new DateTypeInvalidException($value);
-                    };
+                    // Ignore parameter if left empty.
+                    if (!empty($value)) {
+                        try {
+                            $searchActivities = $searchActivities->withDateType(
+                                DateType::fromNative($value)
+                            );
+                        } catch (\InvalidArgumentException $e) {
+                            throw new DateTypeInvalidException($value);
+                        };
+                    }
                     break;
 
                 case 'query':

--- a/src/Response/JsonErrorResponse.php
+++ b/src/Response/JsonErrorResponse.php
@@ -32,7 +32,7 @@ class JsonErrorResponse extends JsonResponse
         }
 
         if ($previous instanceof \CultureFeed_Exception) {
-          $data['user_friendly_message'] = $previous->getUserFriendlyMessage();
+            $data['user_friendly_message'] = $previous->getUserFriendlyMessage();
         }
 
         parent::__construct($data, $exception->getStatusCode(), $exception->getHeaders());

--- a/test/Activity/ActivityControllerTest.php
+++ b/test/Activity/ActivityControllerTest.php
@@ -90,6 +90,21 @@ class ActivityControllerTest extends \PHPUnit_Framework_TestCase
                 ->withSort('permanent desc,availableto asc'),
         ];
 
+        $items['all possible parameters but date type'] = [
+            '0930000467512',
+            [
+                'limit' => 10,
+                'query' => 'foo',
+                'sort' => 'permanent desc,availableto asc',
+                'page' => 2,
+            ],
+            (new SimpleQuery())
+                ->withPagination(new Integer(2), new Integer(10))
+                ->withQuery(new StringLiteral('foo'))
+                ->withUiTPASNumber(new UiTPASNumber('0930000467512'))
+                ->withSort('permanent desc,availableto asc'),
+        ];
+
         $items['next 12 months'] = [
             '0930000208908',
             [


### PR DESCRIPTION
Allow empty "date_type" to skip filtering by date.
See https://jira.uitdatabank.be/browse/UPS-2981.