### PR TITLE
UPS-3168 Fix fatal error for group passes without end date

### DIFF
--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -27,7 +27,7 @@ class Group implements JsonSerializable
     /**
      * End date timestamp.
      *
-     * @var Integer
+     * @var Integer|null
      */
     private $endDate;
 
@@ -39,7 +39,7 @@ class Group implements JsonSerializable
     public function __construct(
         StringLiteral $name,
         Natural $availableTickets,
-        Integer $endDate
+        Integer $endDate = null
     ) {
         $this->name = $name;
         $this->availableTickets = $availableTickets;
@@ -53,11 +53,12 @@ class Group implements JsonSerializable
     public static function fromCultureFeedGroupPass(
         CultureFeed_Uitpas_GroupPass $groupPass
     ) {
+        $endDate = $groupPass->endDate ? new Integer($groupPass->endDate) : null;
 
         return new self(
             new StringLiteral($groupPass->name),
             new Natural($groupPass->availableTickets),
-            new Integer($groupPass->endDate)
+            $endDate
         );
     }
 
@@ -69,7 +70,7 @@ class Group implements JsonSerializable
         return [
             'name' => $this->name->toNative(),
             'availableTickets' => $this->availableTickets->toNative(),
-            'endDate' => $this->endDate->toNative(),
+            'endDate' => $this->endDate ? $this->endDate->toNative() : null,
         ];
     }
 }

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @file
- */
 
 namespace CultuurNet\UiTPASBeheer\Group;
 
@@ -10,7 +7,6 @@ use JsonSerializable;
 use ValueObjects\Number\Integer;
 use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
-use ValueObjects\DateTime\DateTimeWithTimeZone;
 
 class Group implements JsonSerializable
 {
@@ -31,11 +27,6 @@ class Group implements JsonSerializable
      */
     private $endDate;
 
-    /**
-     * @param StringLiteral $name
-     * @param Natural $availableTickets
-     * @param Integer $endDate
-     */
     public function __construct(
         StringLiteral $name,
         Natural $availableTickets,

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -58,10 +58,12 @@ class Group implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        return array_filter([
-            'name' => $this->name->toNative(),
-            'availableTickets' => $this->availableTickets->toNative(),
-            'endDate' => $this->endDate ? $this->endDate->toNative() : null,
-        ]);
+        return array_filter(
+            [
+                'name' => $this->name->toNative(),
+                'availableTickets' => $this->availableTickets->toNative(),
+                'endDate' => $this->endDate ? $this->endDate->toNative() : null,
+            ]
+        );
     }
 }

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -67,10 +67,10 @@ class Group implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        return [
+        return array_filter([
             'name' => $this->name->toNative(),
             'availableTickets' => $this->availableTickets->toNative(),
             'endDate' => $this->endDate ? $this->endDate->toNative() : null,
-        ];
+        ]);
     }
 }

--- a/test/Identity/IdentityTest.php
+++ b/test/Identity/IdentityTest.php
@@ -232,6 +232,17 @@ class IdentityTest extends \PHPUnit_Framework_TestCase
     {
         $json = json_encode($this->identity);
         $this->assertJsonEquals($json, 'Identity/data/identity-minimum.json');
+
+        $groupWithoutEndDate = new Group(
+            new StringLiteral('vereniging'),
+            new Natural(10)
+        );
+
+        $identityWithGroupWithoutEndDate = (new Identity($this->localStockUitpas))
+            ->withGroup($groupWithoutEndDate);
+
+        $json = json_encode($identityWithGroupWithoutEndDate);
+        $this->assertJsonEquals($json, 'Identity/data/identity-minimum-group.json');
     }
 
     /**

--- a/test/Identity/data/identity-minimum-group.json
+++ b/test/Identity/data/identity-minimum-group.json
@@ -1,0 +1,16 @@
+{
+  "uitPas": {
+    "number": "1000000035419",
+    "kansenStatuut": true,
+    "status": "LOCAL_STOCK",
+    "type": "CARD",
+    "cardSystem": {
+      "id": "999",
+      "name": "UiTPAS Regio Aalst"
+    }
+  },
+  "group": {
+    "name": "vereniging",
+    "availableTickets": 10
+  }
+}


### PR DESCRIPTION
### Fixed

- Fixed fatal error (resulting in a "Pass not found" in the frontend) for group passes without end date. When this property was added it was incorrectly assumed that every group pass would have an end date. It's now made optional. Additionally the `endDate` property is not included in the json now if it's `null`, because the frontend attempts to converts the `null` to a date anyway if it sees the `endDate` property.

---

Ticket: https://jira.uitdatabank.be/browse/UPS-3168