### PR TITLE
UPS-3247 Add .zip or .pdf extension to QR code downloads and make it possible to set a custom filename

### DIFF
--- a/app/CheckInCode/CheckInCodeControllerProvider.php
+++ b/app/CheckInCode/CheckInCodeControllerProvider.php
@@ -25,7 +25,8 @@ final class CheckInCodeControllerProvider implements ControllerProviderInterface
         /* @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->get('/checkincodes/{activityId}', 'checkin_code_controller:download');
+        $controllers->get('/checkincodes/{activityId}/{fileName}.pdf', 'checkin_code_controller:downloadPdf');
+        $controllers->get('/checkincodes/{activityId}/{fileName}.zip', 'checkin_code_controller:downloadZip');
 
         return $controllers;
     }

--- a/src/CheckInCode/CheckInCodeController.php
+++ b/src/CheckInCode/CheckInCodeController.php
@@ -20,18 +20,39 @@ final class CheckInCodeController
 
     /**
      * @param string $activityId
-     * @param Request $request
+     * @param string $fileName
      * @return StreamedResponse
      */
-    public function download($activityId, Request $request)
+    public function downloadPdf($activityId, $fileName)
     {
-        $zipped = (bool) $request->get('zipped', false);
-
         $activityId = new StringLiteral($activityId);
-        $download = $this->service->download($activityId, $zipped);
+        $download = $this->service->download($activityId, false);
+        return $this->convertDownloadToStreamedResponse($download, $fileName . '.pdf');
+    }
 
+    /**
+     * @param string $activityId
+     * @param string $fileName
+     * @return StreamedResponse
+     */
+    public function downloadZip($activityId, $fileName)
+    {
+        $activityId = new StringLiteral($activityId);
+        $download = $this->service->download($activityId, true);
+        return $this->convertDownloadToStreamedResponse($download, $fileName . '.zip');
+    }
+
+    /**
+     * @param CheckInCodeDownload $download
+     * @param string $fileName
+     * @return StreamedResponse
+     */
+    private function convertDownloadToStreamedResponse(CheckInCodeDownload $download, $fileName)
+    {
         $headers = $download->getHeaders();
         $stream = $download->getStream();
+
+        $headers['Content-Disposition'] = 'attachment; filename="' . $fileName . '"';
 
         $streamCallback = function () use ($stream) {
             $stream->rewind();

--- a/src/CheckInCode/CheckInCodeController.php
+++ b/src/CheckInCode/CheckInCodeController.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UiTPASBeheer\CheckInCode;
 
+use CultuurNet\UiTPASBeheer\Http\ContentDispositionHeader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -49,10 +50,12 @@ final class CheckInCodeController
      */
     private function convertDownloadToStreamedResponse(CheckInCodeDownload $download, $fileName)
     {
+        $download = $download->withContentDispositionHeader(
+            ContentDispositionHeader::fromFileName($fileName)
+        );
+
         $headers = $download->getHeaders();
         $stream = $download->getStream();
-
-        $headers['Content-Disposition'] = 'attachment; filename="' . $fileName . '"';
 
         $streamCallback = function () use ($stream) {
             $stream->rewind();

--- a/src/CheckInCode/CheckInCodeDownload.php
+++ b/src/CheckInCode/CheckInCodeDownload.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UiTPASBeheer\CheckInCode;
 
+use CultuurNet\UiTPASBeheer\Http\ContentDispositionHeader;
 use Guzzle\Stream\StreamInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
@@ -18,19 +19,19 @@ final class CheckInCodeDownload
     private $contentTypeHeader;
 
     /**
-     * @var StringLiteral
+     * @var ContentDispositionHeader
      */
     private $contentDispositionHeader;
 
     /**
      * @param StreamInterface $stream
      * @param StringLiteral $contentTypeHeader
-     * @param StringLiteral $contentDispositionHeader
+     * @param ContentDispositionHeader $contentDispositionHeader
      */
     public function __construct(
         StreamInterface $stream,
         StringLiteral $contentTypeHeader,
-        StringLiteral $contentDispositionHeader
+        ContentDispositionHeader $contentDispositionHeader
     ) {
         $this->stream = $stream;
         $this->contentTypeHeader = $contentTypeHeader;
@@ -43,6 +44,17 @@ final class CheckInCodeDownload
     public function getStream()
     {
         return $this->stream;
+    }
+
+    /**
+     * @param ContentDispositionHeader $contentDispositionHeader
+     * @return self
+     */
+    public function withContentDispositionHeader(ContentDispositionHeader $contentDispositionHeader)
+    {
+        $c = clone $this;
+        $c->contentDispositionHeader = $contentDispositionHeader;
+        return $c;
     }
 
     /**

--- a/src/CheckInCode/CheckInCodeService.php
+++ b/src/CheckInCode/CheckInCodeService.php
@@ -6,6 +6,7 @@ use CultuurNet\Auth\ConsumerCredentials;
 use CultuurNet\Auth\Guzzle\OAuthProtectedService;
 use CultuurNet\Auth\TokenCredentials;
 use CultuurNet\UiTPASBeheer\Counter\CounterConsumerKey;
+use CultuurNet\UiTPASBeheer\Http\ContentDispositionHeader;
 use Guzzle\Http\Exception\ClientErrorResponseException;
 use ValueObjects\StringLiteral\StringLiteral;
 
@@ -82,7 +83,7 @@ final class CheckInCodeService extends OAuthProtectedService implements CheckInC
         return new CheckInCodeDownload(
             $contentStream,
             new StringLiteral((string) $contentType),
-            new StringLiteral((string) $contentDisposition)
+            new ContentDispositionHeader((string) $contentDisposition)
         );
     }
 }

--- a/src/Http/ContentDispositionHeader.php
+++ b/src/Http/ContentDispositionHeader.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CultuurNet\UiTPASBeheer\Http;
+
+use ValueObjects\StringLiteral\StringLiteral;
+
+final class ContentDispositionHeader extends StringLiteral
+{
+    /**
+     * @param string $fileName
+     * @return self
+     */
+    public static function fromFileName($fileName)
+    {
+        return new self('attachment; filename="' . $fileName . '"');
+    }
+}

--- a/test/CheckInCode/CheckInCodeControllerTest.php
+++ b/test/CheckInCode/CheckInCodeControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UiTPASBeheer\CheckInCode;
 
+use CultuurNet\UiTPASBeheer\Http\ContentDispositionHeader;
 use Guzzle\Http\EntityBody;
 use ValueObjects\StringLiteral\StringLiteral;
 
@@ -41,7 +42,7 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
                 fopen($filePath, 'r')
             ),
             new StringLiteral($contentType),
-            new StringLiteral($originalContentDisposition)
+            new ContentDispositionHeader($originalContentDisposition)
         );
 
         $this->service->expects($this->once())
@@ -90,7 +91,7 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
                 fopen($filePath, 'r')
             ),
             new StringLiteral($contentType),
-            new StringLiteral($originalContentDisposition)
+            new ContentDispositionHeader($originalContentDisposition)
         );
 
         $this->service->expects($this->once())

--- a/test/CheckInCode/CheckInCodeControllerTest.php
+++ b/test/CheckInCode/CheckInCodeControllerTest.php
@@ -3,7 +3,6 @@
 namespace CultuurNet\UiTPASBeheer\CheckInCode;
 
 use Guzzle\Http\EntityBody;
-use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
@@ -30,19 +29,19 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
     public function it_responds_a_stream_when_downloading_as_zip()
     {
         $id = new StringLiteral('8a01e635-cbf2-4879-bdee-aea5f3066627');
-        $request = new Request(['zipped' => true]);
+        $fileName = 'qr-spaarcode-ancienne-belgique';
 
         $filePath = __DIR__ . '/data/UITPAS_QR_Ancienne_Belgique.zip';
 
         $contentType = 'application/x-zip-compressed';
-        $contentDisposition = 'attachment; filename="UITPAS_QR_Ancienne_Belgique.zip"';
+        $originalContentDisposition = 'attachment; filename="UITPAS_QR_Ancienne_Belgique.zip"';
 
         $download = new CheckInCodeDownload(
             EntityBody::factory(
                 fopen($filePath, 'r')
             ),
             new StringLiteral($contentType),
-            new StringLiteral($contentDisposition)
+            new StringLiteral($originalContentDisposition)
         );
 
         $this->service->expects($this->once())
@@ -50,7 +49,7 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
             ->with($id)
             ->willReturn($download);
 
-        $response = $this->controller->download($id->toNative(), $request);
+        $response = $this->controller->downloadZip($id->toNative(), $fileName);
 
         $this->assertEquals(
             $contentType,
@@ -58,7 +57,7 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            $contentDisposition,
+            'attachment; filename="qr-spaarcode-ancienne-belgique.zip"',
             $response->headers->get('Content-Disposition')
         );
 
@@ -79,19 +78,19 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
     public function it_responds_a_stream_when_downloading_as_pdf()
     {
         $id = new StringLiteral('8a01e635-cbf2-4879-bdee-aea5f3066627');
-        $request = new Request(['zipped' => false]);
+        $fileName = 'qr-spaarcode-ancienne-belgique';
 
         $filePath = __DIR__ . '/data/UITPAS_QR_Ancienne_Belgique.pdf';
 
         $contentType = 'application/pdf';
-        $contentDisposition = 'attachment; filename="UITPAS_QR_Ancienne_Belgique.pdf"';
+        $originalContentDisposition = 'attachment; filename="UITPAS_QR_Ancienne_Belgique.pdf"';
 
         $download = new CheckInCodeDownload(
             EntityBody::factory(
                 fopen($filePath, 'r')
             ),
             new StringLiteral($contentType),
-            new StringLiteral($contentDisposition)
+            new StringLiteral($originalContentDisposition)
         );
 
         $this->service->expects($this->once())
@@ -99,7 +98,7 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
             ->with($id)
             ->willReturn($download);
 
-        $response = $this->controller->download($id->toNative(), $request);
+        $response = $this->controller->downloadPdf($id->toNative(), $fileName);
 
         $this->assertEquals(
             $contentType,
@@ -107,7 +106,7 @@ final class CheckInCodeControllerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            $contentDisposition,
+            'attachment; filename="qr-spaarcode-ancienne-belgique.pdf"',
             $response->headers->get('Content-Disposition')
         );
 

--- a/test/CheckInCode/CheckInCodeServiceTest.php
+++ b/test/CheckInCode/CheckInCodeServiceTest.php
@@ -7,6 +7,7 @@ use CultuurNet\Auth\Guzzle\DefaultHttpClientFactory;
 use CultuurNet\Auth\TokenCredentials;
 use CultuurNet\UiTPASBeheer\Counter\CounterConsumerKey;
 use CultuurNet\UiTPASBeheer\ExpenseReport\Properties\ExpenseReportId;
+use CultuurNet\UiTPASBeheer\Http\ContentDispositionHeader;
 use Guzzle\Http\EntityBody;
 use Guzzle\Http\Message\MessageInterface;
 use Guzzle\Http\Message\RequestInterface;
@@ -78,7 +79,7 @@ final class CheckInCodeServiceTest extends \PHPUnit_Framework_TestCase
         $expected = new CheckInCodeDownload(
             $responseBody,
             new StringLiteral('application/x-zip-compressed'),
-            new StringLiteral($contentDispositionHeader)
+            new ContentDispositionHeader($contentDispositionHeader)
         );
 
         $actual = $this->service->download($id, true);
@@ -124,7 +125,7 @@ final class CheckInCodeServiceTest extends \PHPUnit_Framework_TestCase
         $expected = new CheckInCodeDownload(
             $responseBody,
             new StringLiteral('application/pdf'),
-            new StringLiteral($contentDispositionHeader)
+            new ContentDispositionHeader($contentDispositionHeader)
         );
 
         $actual = $this->service->download($id, false);


### PR DESCRIPTION
### Changed
 
- Changed the download endpoint for QR codes so it ends in either `.pdf` or `.zip` for browsers that don't take the `Content-Disposition` header into account (aka the custom UiTPAS Balie browser which our balies use to have an integration with the UiTPAS card scanner)
- Changed the download endpoint for QR codes to make it possible to set a custom filename.
 
---

Ticket: https://jira.uitdatabank.be/browse/UPS-3247
