### PR TITLE
Run Github Actions on 7.2, 7.3, and 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['5.6', '7.1']
+                php-versions: ['5.6', '7.1', '7.2', '7.3', '7.4']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
### Added
 
- Added Github Actions configuration to run the jobs on PHP 7.2, 7.3, and 7.4 to check compatibility.
