### PR TITLE
UPS-3269 Auth0 login

### DIFF
--- a/app/Auth/AuthControllerProvider.php
+++ b/app/Auth/AuthControllerProvider.php
@@ -13,15 +13,17 @@ final class AuthControllerProvider implements ControllerProviderInterface
 {
     public function connect(Application $app): ControllerCollection
     {
-        $app['auth_controller'] = $app->share(function (Application $app) {
-            return new AuthController(
-                $app[Auth0::class],
-                $app['session'],
-                $app['uitid_user_session_service'],
-                $app[UiTIDv1TokenService::class],
-                $app['config']['auth0']['app_url']
-            );
-        });
+        $app['auth_controller'] = $app->share(
+            function (Application $app) {
+                return new AuthController(
+                    $app[Auth0::class],
+                    $app['session'],
+                    $app['uitid_user_session_service'],
+                    $app[UiTIDv1TokenService::class],
+                    $app['config']['auth0']['app_url']
+                );
+            }
+        );
 
         $controllers = $app['controllers_factory'];
 

--- a/app/Auth/AuthControllerProvider.php
+++ b/app/Auth/AuthControllerProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UiTPASBeheer\Auth;
+
+use Auth0\SDK\Auth0;
+use Silex\Application;
+use Silex\ControllerCollection;
+use Silex\ControllerProviderInterface;
+
+final class AuthControllerProvider implements ControllerProviderInterface
+{
+    public function connect(Application $app): ControllerCollection
+    {
+        $app['auth_controller'] = $app->share(function (Application $app) {
+            return new AuthController(
+                $app[Auth0::class],
+                $app['session'],
+                $app['uitid_user_session_service'],
+                $app[UiTIDv1TokenService::class],
+                $app['config']['auth0']['app_url']
+            );
+        });
+
+        $controllers = $app['controllers_factory'];
+
+        $controllers->get('/connect', 'auth_controller:redirectToLoginService');
+        $controllers->get('/authorize', 'auth_controller:storeTokenAndRedirectToFrontend');
+
+        return $controllers;
+    }
+}

--- a/app/Auth/AuthServiceProvider.php
+++ b/app/Auth/AuthServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UiTPASBeheer\Auth;
+
+use Auth0\SDK\Auth0;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+
+final class AuthServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app): void
+    {
+        $app[Auth0::class] = $app::share(
+            function (Application $app) {
+                return new Auth0(
+                    [
+                        'domain' => $app['config']['auth0']['domain'],
+                        'client_id' => $app['config']['auth0']['client_id'],
+                        'client_secret' => $app['config']['auth0']['client_secret'],
+                        'redirect_uri' => $app['config']['auth0']['callback_url'],
+                        'scope' => 'openid email profile offline_access https://api.publiq.be/auth/uitpas_balie',
+                        'audience' => 'https://api.publiq.be',
+                        'persist_id_token' => false,
+                        'id_token_leeway' => 30,
+                    ]
+                );
+            }
+        );
+
+        $app[UiTIDv1TokenService::class] = $app::share(
+            function (Application $app) {
+                return new UiTIDv1TokenService(
+                    $app['config']['uitid']['base_url'],
+                    $app['culturefeed_consumer_credentials']
+                );
+            }
+        );
+    }
+
+    public function boot(Application $app): void
+    {
+
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+use CultuurNet\UiTPASBeheer\Auth\AuthServiceProvider;
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 $app = new Silex\Application();
@@ -90,9 +92,14 @@ $app->register(new \CultuurNet\UiTPASBeheer\CulturefeedGuzzleServiceProvider());
 $app->register(new Silex\Provider\UrlGeneratorServiceProvider());
 
 /**
- * UiTID Authentication services.
+ * Authentication services
  */
-$app->register(new CultuurNet\UiTIDProvider\Auth\AuthServiceProvider());
+$app['auth0_enabled'] = isset($app['config']['auth0']['enable']) && $app['config']['auth0']['enable'] === true;
+if ($app['auth0_enabled']) {
+    $app->register(new AuthServiceProvider());
+} else {
+    $app->register(new CultuurNet\UiTIDProvider\Auth\AuthServiceProvider());
+}
 
 /**
  * UiTID User services.

--- a/bootstrap/logging.php
+++ b/bootstrap/logging.php
@@ -30,24 +30,26 @@ $app['third_party_api_logger_factory'] = $app->protect(
     }
 );
 
-$app['uitid_auth_service'] = $app->share(
-    $app->extend(
-        'uitid_auth_service',
-        function (\CultuurNet\Auth\Guzzle\Service $service, \Silex\Application $app) {
-            /** @var \Psr\Log\LoggerInterface $logger */
-            $logger = $app['third_party_api_logger_factory']('cultuurnet_auth');
+if (!$app['auth0_enabled']) {
+    $app['uitid_auth_service'] = $app->share(
+        $app->extend(
+            'uitid_auth_service',
+            function (\CultuurNet\Auth\Guzzle\Service $service, \Silex\Application $app) {
+                /** @var \Psr\Log\LoggerInterface $logger */
+                $logger = $app['third_party_api_logger_factory']('cultuurnet_auth');
 
-            $logPlugin = new \Guzzle\Plugin\Log\LogPlugin(
-                new \Guzzle\Log\PsrLogAdapter($logger),
-                MESSAGE_FORMAT
-            );
+                $logPlugin = new \Guzzle\Plugin\Log\LogPlugin(
+                    new \Guzzle\Log\PsrLogAdapter($logger),
+                    MESSAGE_FORMAT
+                );
 
-            $service->addSubscriber($logPlugin);
+                $service->addSubscriber($logPlugin);
 
-            return $service;
-        }
-    )
-);
+                return $service;
+            }
+        )
+    );
+}
 
 /**
  * Enable logging on the guzzle client of Culturefeed.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "cultuurnet/hydra": "~0.1",
     "2dotstwice/collection": "~1.0",
     "paybreak/luhn": "^0.2.0",
-    "monolog/monolog": "^1.17.2"
+    "monolog/monolog": "^1.17.2",
+    "auth0/auth0-php": "7.5.0"
   },
   "require-dev": {
     "escapestudios/symfony2-coding-standard": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cdca64ca36cb3816e0ad0b0ff814b5d",
+    "content-hash": "8b9fdd0399622fe1007d33269f68fd1b",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -55,6 +55,56 @@
             ],
             "description": " Library for creating collection classes with strict typing.",
             "time": "2015-09-18T17:46:29+00:00"
+        },
+        {
+            "name": "auth0/auth0-php",
+            "version": "7.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/auth0/auth0-PHP.git",
+                "reference": "29c74a3d6c7ff7c3c1d294d204ecabcb83e589e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/auth0/auth0-PHP/zipball/29c74a3d6c7ff7c3c1d294d204ecabcb83e589e1",
+                "reference": "29c74a3d6c7ff7c3c1d294d204ecabcb83e589e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "~6.0 | ~7.0",
+                "lcobucci/jwt": "^3.3",
+                "php": "^7.1",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "josegonzalez/dotenv": "^2.0",
+                "phpcompatibility/php-compatibility": "^8.1",
+                "phpunit/phpunit": "^7.0",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Auth0\\SDK\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Auth0",
+                    "email": "support@auth0.com",
+                    "homepage": "http://www.auth0.com/"
+                }
+            ],
+            "description": "Auth0 PHP SDK.",
+            "homepage": "https://github.com/auth0/auth0-PHP",
+            "time": "2020-11-16T13:00:36+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -657,6 +707,195 @@
             "time": "2015-03-18T18:23:50+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.17.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2020-06-16T21:01:06+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
+                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2020-09-30T07:37:28+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3",
+                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2020-09-30T07:37:11+00:00"
+        },
+        {
             "name": "jdesrosiers/silex-cors-provider",
             "version": "v0.1.5",
             "source": {
@@ -771,6 +1010,79 @@
                 "schema"
             ],
             "time": "2016-01-25T15:43:01+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "3.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "~1.5",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/php-invoker": "~1.1",
+                "phpunit/phpunit": "^5.7 || ^7.3",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "suggest": {
+                "lcobucci/clock": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                },
+                "files": [
+                    "compat/class-aliases.php",
+                    "compat/json-exception-polyfill.php",
+                    "compat/lcobucci-clock-polyfill.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-02-16T09:40:01+00:00"
         },
         {
             "name": "league/geotools",
@@ -1174,6 +1486,56 @@
             "time": "2013-11-22T08:30:29+00:00"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -1219,6 +1581,94 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -2336,6 +2786,171 @@
             "time": "2021-01-22T09:19:47+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.22.1",
             "source": {
@@ -2591,6 +3206,79 @@
                 "shim"
             ],
             "time": "2016-01-25T08:44:42+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-util",

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -17,6 +17,13 @@ uitid:
   # Base URL of the UiTID API.
   #base_url: https://acc.uitid.be/uitid/rest/
   base_url: http://www.uitid.be/uitid/rest/
+auth0:
+  enable: true
+  domain: publiq-acc.eu.auth0.com
+  client_id: ***
+  client_secret: ***
+  callback_url: https://balie.uitpas.dev/oauth/culturefeed/authorize
+  app_url: https://balie.uitpas.dev/app
 # UiT Search API related settings.
 search:
   # Base URL of the UiT Search API.

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -42,5 +42,6 @@
 
         <exclude name="Zend.Debug.CodeAnalyzer" />
         <exclude name="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
+        <exclude name="Zend.NamingConventions.ValidVariableName.ContainsNumbers" />
     </rule>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -43,5 +43,6 @@
         <exclude name="Zend.Debug.CodeAnalyzer" />
         <exclude name="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
         <exclude name="Zend.NamingConventions.ValidVariableName.ContainsNumbers" />
+        <exclude name="Zend.NamingConventions.ValidVariableName.MemberVarContainsNumbers" />
     </rule>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -42,6 +42,5 @@
 
         <exclude name="Zend.Debug.CodeAnalyzer" />
         <exclude name="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
-        <exclude name="Zend.NamingConventions.ValidVariableName.ContainsNumbers" />
     </rule>
 </ruleset>

--- a/src/Auth/AuthController.php
+++ b/src/Auth/AuthController.php
@@ -52,7 +52,7 @@ final class AuthController
 
     public function redirectToLoginService(): void
     {
-        // The Balie app is not mulitlingual, so locale can always be NL.
+        // The Balie app is not multilingual, so locale can always be NL.
         // The ui_type=minimal parameter is needed to show a simple login screen without social logins etc.
         // The prompt=login parameter is needed to always force the user to login again, even if the user is still
         // technically logged in on Auth0.

--- a/src/Auth/AuthController.php
+++ b/src/Auth/AuthController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UiTPASBeheer\Auth;
+
+use Auth0\SDK\Auth0;
+use CultuurNet\UiTIDProvider\User\UserSessionService;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final class AuthController
+{
+    /**
+     * @var Auth0
+     */
+    private $auth0;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var UserSessionService
+     */
+    private $userSessionService;
+
+    /**
+     * @var UiTIDv1TokenService
+     */
+    private $uitIDv1TokenService;
+
+    /**
+     * @var string
+     */
+    private $redirectUrlAfterLogin;
+
+    public function __construct(
+        Auth0 $auth0,
+        SessionInterface $session,
+        UserSessionService $userSessionService,
+        UiTIDv1TokenService $uitIDv1TokenService,
+        string $redirectUrlAfterLogin
+    ) {
+        $this->auth0 = $auth0;
+        $this->session = $session;
+        $this->userSessionService = $userSessionService;
+        $this->uitIDv1TokenService = $uitIDv1TokenService;
+        $this->redirectUrlAfterLogin = $redirectUrlAfterLogin;
+    }
+
+    public function redirectToLoginService(): void
+    {
+        // The Balie app is not mulitlingual, so locale can always be NL.
+        // The ui_type=minimal parameter is needed to show a simple login screen without social logins etc.
+        // The prompt=login parameter is needed to always force the user to login again, even if the user is still
+        // technically logged in on Auth0.
+        $params = [
+            'locale' => 'nl',
+            'ui_type' => 'minimal',
+            'prompt' => 'login',
+        ];
+
+        // The Auth0 SDK sets a Location header and then exits, so we do not need to return a Response object.
+        $this->auth0->login(null, null, $params);
+    }
+
+    public function storeTokenAndRedirectToFrontend(): RedirectResponse
+    {
+        $accessToken = $this->auth0->getAccessToken();
+        $uitIDv1Token = $this->uitIDv1TokenService->getV1TokenForAuth0AccessToken($accessToken);
+
+        // Store the Auth0 access token so the frontend can request it later to access the Balie Insights API.
+        $this->session->set('auth0_access_token', $accessToken);
+
+        // Store the v1 token and user id in the pre-existing UserSessionService so the rest of the app keeps working as
+        // before.
+        $this->userSessionService->setMinimalUserInfo($uitIDv1Token);
+
+        return new RedirectResponse($this->redirectUrlAfterLogin);
+    }
+}

--- a/src/Auth/UiTIDv1TokenException.php
+++ b/src/Auth/UiTIDv1TokenException.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UiTPASBeheer\Auth;
+
+use CultuurNet\UiTPASBeheer\Exception\ResponseException;
+
+final class UiTIDv1TokenException extends ResponseException
+{
+    public static function unauthorized(): self
+    {
+        return new self(
+            'Could not exchange token with UiTID v1 because the auth0 token was not found by UiTID v1.',
+            401
+        );
+    }
+
+    public static function noPermission(): self
+    {
+        return new self(
+            'Could not exchange token with UiTID v1 because the oauth consumer has no permission to so.',
+            403
+        );
+    }
+
+    public static function unknown(int $code = null, string $reason = null): self
+    {
+        return new self(
+            sprintf(
+                'Could not exchange token with UiTID v1 for unknown reason (code: %s, reason: %s)',
+                $code,
+                $reason
+            ),
+            $code ?? 500
+        );
+    }
+
+    public static function invalidXmlResponse(string $details): self
+    {
+        return new self(
+            'Could not exchange token with UiTID v1 because the response XML is invalid. ' . $details,
+            500
+        );
+    }
+
+    public static function failed(string $message): self
+    {
+        return new self(
+            'Token exchange with UiTID v1 failed. Reason: ' . $message,
+            500
+        );
+    }
+}

--- a/src/Auth/UiTIDv1TokenException.php
+++ b/src/Auth/UiTIDv1TokenException.php
@@ -19,7 +19,7 @@ final class UiTIDv1TokenException extends ResponseException
     public static function noPermission(): self
     {
         return new self(
-            'Could not exchange token with UiTID v1 because the oauth consumer has no permission to so.',
+            'Could not exchange token with UiTID v1 because the oauth consumer has no permission to do so.',
             403
         );
     }

--- a/src/Auth/UiTIDv1TokenService.php
+++ b/src/Auth/UiTIDv1TokenService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UiTPASBeheer\Auth;
+
+use CultureFeed_SimpleXMLElement;
+use CultuurNet\Auth\Guzzle\OAuthProtectedService;
+use CultuurNet\Auth\TokenCredentials;
+use CultuurNet\Auth\User;
+use Exception;
+use Guzzle\Http\Exception\BadResponseException;
+
+final class UiTIDv1TokenService extends OAuthProtectedService
+{
+    private const CODE_FAILED = 'FAILED';
+
+    /**
+     * Exchanges an Auth0 token for a UiTID v1 token and secret, and the corresponding user id.
+     * @see https://jira.uitdatabank.be/browse/UPS-3180#comment-105142
+     * @throws UiTIDv1TokenException
+     */
+    public function getV1TokenForAuth0AccessToken(string $auth0AccessToken): User
+    {
+        // Get a HTTP client pre-configured to make requests to UiTID v1.
+        $client = $this->getClient();
+
+        // Prepare a POST request to the endpoint where we can exchange the Auth0 token.
+        $request = $client->post('authapi/auth0at');
+        $request->addPostFields(['at' => $auth0AccessToken]);
+
+        try {
+            $response = $request->send();
+        } catch (BadResponseException $exception) {
+            // If the response status code is not 200, try to throw an informative exception based on the known status
+            // codes the endpoint can return.
+            $response = $exception->getResponse();
+
+            switch ($response->getStatusCode()) {
+                case 401:
+                    throw UiTIDv1TokenException::unauthorized();
+
+                case 403:
+                    throw UiTIDv1TokenException::noPermission();
+
+                default:
+                    throw UiTIDv1TokenException::unknown($response->getStatusCode(), $response->getReasonPhrase());
+            }
+        }
+
+        $responseBody = $response->getBody(true);
+
+        try {
+            $xml = new CultureFeed_SimpleXMLElement($responseBody);
+        } catch (Exception $e) {
+            throw UiTIDv1TokenException::invalidXmlResponse('Could not parse XML.');
+        }
+
+        // The <response><code> tag will contain SUCCESS or FAILED.
+        // If it's not found or contains FAILED, throw an exception.
+        $code = $xml->xpath_str('/response/code');
+        if ($code === null) {
+            throw UiTIDv1TokenException::invalidXmlResponse('/response/code missing');
+        }
+        if ($code === self::CODE_FAILED) {
+            $message = $code = $xml->xpath_str('/response/message');
+            if ($message === null) {
+                throw UiTIDv1TokenException::invalidXmlResponse('/response/message missing');
+            }
+            throw UiTIDv1TokenException::failed($message);
+        }
+
+        $token = $xml->xpath_str('/response/token/token');
+        $secret = $xml->xpath_str('/response/token/tokenSecret');
+        $userId = $xml->xpath_str('/response/token/user/uid');
+
+        if ($token === null) {
+            throw UiTIDv1TokenException::invalidXmlResponse('/response/token/token missing.');
+        }
+        if ($secret === null) {
+            throw UiTIDv1TokenException::invalidXmlResponse('/response/token/tokenSecret missing.');
+        }
+        if ($userId === null) {
+            throw UiTIDv1TokenException::invalidXmlResponse('/response/token/user/uid missing.');
+        }
+
+        return new User($userId, new TokenCredentials($token, $secret));
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use CultuurNet\UiTPASBeheer\Auth\AuthControllerProvider;
 use CultuurNet\UiTPASBeheer\GroupPass\GroupPassControllerProvider;
 use Silex\Application;
 
@@ -46,7 +47,11 @@ $app->register(new \CultuurNet\UiTPASBeheer\JsonPostDataServiceProvider());
 /**
  * API callbacks for authentication.
  */
-$app->mount('culturefeed/oauth', new \CultuurNet\UiTIDProvider\Auth\AuthControllerProvider());
+if ($app['auth0_enabled']) {
+    $app->mount('culturefeed/oauth', new AuthControllerProvider());
+} else {
+    $app->mount('culturefeed/oauth', new \CultuurNet\UiTIDProvider\Auth\AuthControllerProvider());
+}
 
 /**
  * API callbacks for UiTID user data and methods.


### PR DESCRIPTION
### Added
 
- Added Auth0 login, if enabled in config
 
---

Summary of the context: We need to switch over to Auth0 as part of the findings of a security audit, and also to enable the frontend to start using the new Balie Insights API that our data team built (which uses Auth0 tokens). However, the underlying UiTPAS API used by Balie still requires the UiTID v1 OAuth2 tokens at this point. So this keep everything working, a temporary method was added to exchange Auth0 tokens for UiTID v1 tokens.

The changes in this PR are limited to making it possible to log in with Auth0 (if enabled), and keeping the rest of the app working as-is.

To make it possible for the frontend to use the Auth0 token to access the Balie Insights API, a new PR will be created with a new endpoint for the frontend to fetch the Auth0 token from the backend.

Ticket: https://jira.uitdatabank.be/browse/UPS-3269

For more info, see the analysis in https://jira.uitdatabank.be/browse/UPS-3335#comment-106232
