### PR TITLE
UPS-3426 Add endpoint to get Auth0 access token

### DIFF
--- a/app/Auth/AuthControllerProvider.php
+++ b/app/Auth/AuthControllerProvider.php
@@ -29,6 +29,7 @@ final class AuthControllerProvider implements ControllerProviderInterface
 
         $controllers->get('/connect', 'auth_controller:redirectToLoginService');
         $controllers->get('/authorize', 'auth_controller:storeTokenAndRedirectToFrontend');
+        $controllers->get('/token', 'auth_controller:getToken');
 
         return $controllers;
     }

--- a/src/Auth/AccessTokenNotFoundException.php
+++ b/src/Auth/AccessTokenNotFoundException.php
@@ -9,7 +9,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class AccessTokenNotFoundException extends ResponseException
 {
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct('No access token found.', Response::HTTP_NOT_FOUND);
     }
 }

--- a/src/Auth/AccessTokenNotFoundException.php
+++ b/src/Auth/AccessTokenNotFoundException.php
@@ -10,6 +10,6 @@ use Symfony\Component\HttpFoundation\Response;
 final class AccessTokenNotFoundException extends ResponseException
 {
     public function __construct() {
-        parent::__construct('No access token found.', 'ACCESS_TOKEN_NOT_FOUND', Response::HTTP_NOT_FOUND);
+        parent::__construct('No access token found.', Response::HTTP_NOT_FOUND);
     }
 }

--- a/src/Auth/AccessTokenNotFoundException.php
+++ b/src/Auth/AccessTokenNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UiTPASBeheer\Auth;
+
+use CultuurNet\UiTPASBeheer\Exception\ResponseException;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AccessTokenNotFoundException extends ResponseException
+{
+    public function __construct() {
+        parent::__construct('No access token found.', 'ACCESS_TOKEN_NOT_FOUND', Response::HTTP_NOT_FOUND);
+    }
+}

--- a/src/Auth/AuthController.php
+++ b/src/Auth/AuthController.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UiTPASBeheer\Auth;
 
 use Auth0\SDK\Auth0;
 use CultuurNet\UiTIDProvider\User\UserSessionService;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -79,5 +80,16 @@ final class AuthController
         $this->userSessionService->setMinimalUserInfo($uitIDv1Token);
 
         return new RedirectResponse($this->redirectUrlAfterLogin);
+    }
+
+    public function getToken(): JsonResponse
+    {
+        $accessToken = $this->session->get('auth0_access_token', null);
+
+        if ($accessToken === null) {
+            throw new AccessTokenNotFoundException();
+        }
+
+        return new JsonResponse(['token' => $accessToken]);
     }
 }

--- a/web/swagger.json
+++ b/web/swagger.json
@@ -44,6 +44,29 @@
         ]
       }
     },
+    "/culturefeed/oauth/token": {
+      "get": {
+        "summary": "Get the Auth0 access token for the current user.",
+        "operationId": "oauthGetAccessToken",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The Auth0 access token for the current user. Has the audience https://api.publiq.be and scope https://api.publiq.be/auth/uitpas_balie",
+            "schema": {
+              "$ref": "#/definitions/AccessToken"
+            }
+          },
+          "404": {
+            "description": "No access token found for the current user (which means the user is not logged in)."
+          }
+        },
+        "tags": [
+          "OAuth"
+        ]
+      }
+    },
     "/uitid/user": {
       "get": {
         "summary": "Retrieve all information about the current user.",
@@ -2154,6 +2177,14 @@
     }
   ],
   "definitions": {
+    "AccessToken": {
+      "properties": {
+        "token": {
+          "type": "string",
+          "example": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik56SkJOamRGTkRkQ09FUkdNek00TlRKRlFVUXhOek0xTVRnMU5UYzFSalJHUWpsRk4wSkRRUSJ9.eyJpc3MiOiJodHRwczovL3B1YmxpcS1hY2MuZXUuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDk2ZmQ2YzEzLWVhYWItNGRkMS1iYjZhLTFjNDgzZDVlNDBjYyIsImF1ZCI6WyJodHRwczovL2FwaS5wdWJsaXEuYmUiLCJodHRwczovL3B1YmxpcS1hY2MuZXUuYXV0aDAuY29tL3VzZXJpbmZvIl0sImlhdCI6MTYxMzc0MzY1NCwiZXhwIjoxNjEzODMwMDU0LCJhenAiOiJrb3JXbGN3ZktsTWNjb0pHMXhtNzVoOENSRlNGWFR6aCIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwgaHR0cHM6Ly9hcGkucHVibGlxLmJlL2F1dGgvdWl0cGFzX2JhbGllIn0.VjIu1rOeu-PXFTpuyWlHaVuT0qXb4A1hybh0KExoPx4iE32gEYy1ChiCCeXfqcDrm8SlQq0dvroMex5c2z4NxC-E-VZ_RzS0uowGRY6PTDwBtGYIG1-7l4Uc6b9Zx7HkiLCIDYB3U4FhhDNw7QrSOyKOd2LgOdpu9Ruv8jZv71qtybhDj-UP73iUfXoUoRdk5-9YlfkFYMEo26QwVLYfmvcPK76qs1JOhaAJU8SmySqwYy3DX7aVy87-wsGea8oHgpAG3jOV8n9I61QbOD0bxYnzLS5xtTGHrYB4REq7gNRjY2Vpf08IO7QNoxez25SbOnFgepokcG9rFY2aE87ASA"
+        }
+      }
+    },
     "User": {
       "properties": {
         "id": {


### PR DESCRIPTION
### Added
 
- Added endpoint to return the Auth0 access token stored in the PHP session. This makes it possible for the front-end to integrate with the new Balie Insights API that uses Auth0 tokens.

---

Ticket: https://jira.uitdatabank.be/browse/UPS-3426

Some security info:
The Balie backend itself doesn't use the Auth0 access token for authentication. Instead it works with a PHP session. So if we find a token in the current session, then the user is already logged in according to the Balie app. An access token should also not be used as authentication token anyway, it contains less info than an id token. https://auth0.com/docs/tokens#access-tokens
