### PR TITLE
Make login parameters configurable

### DIFF
--- a/app/Auth/AuthControllerProvider.php
+++ b/app/Auth/AuthControllerProvider.php
@@ -20,6 +20,7 @@ final class AuthControllerProvider implements ControllerProviderInterface
                     $app['session'],
                     $app['uitid_user_session_service'],
                     $app[UiTIDv1TokenService::class],
+                    $app['config']['auth0']['login_parameters'],
                     $app['config']['auth0']['app_url']
                 );
             }

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -24,6 +24,10 @@ auth0:
   client_secret: ***
   callback_url: https://balie.uitpas.dev/oauth/culturefeed/authorize
   app_url: https://balie.uitpas.dev/app
+  login_parameters:
+    locale: nl
+    referrer: uitpas
+    prompt: login
 # UiT Search API related settings.
 search:
   # Base URL of the UiT Search API.

--- a/src/Auth/AuthController.php
+++ b/src/Auth/AuthController.php
@@ -33,6 +33,11 @@ final class AuthController
     private $uitIDv1TokenService;
 
     /**
+     * @var string[]
+     */
+    private $loginParameters;
+
+    /**
      * @var string
      */
     private $redirectUrlAfterLogin;
@@ -42,29 +47,21 @@ final class AuthController
         SessionInterface $session,
         UserSessionService $userSessionService,
         UiTIDv1TokenService $uitIDv1TokenService,
+        array $loginParameters,
         string $redirectUrlAfterLogin
     ) {
         $this->auth0 = $auth0;
         $this->session = $session;
         $this->userSessionService = $userSessionService;
         $this->uitIDv1TokenService = $uitIDv1TokenService;
+        $this->loginParameters = $loginParameters;
         $this->redirectUrlAfterLogin = $redirectUrlAfterLogin;
     }
 
     public function redirectToLoginService(): void
     {
-        // The Balie app is not multilingual, so locale can always be NL.
-        // The ui_type=minimal parameter is needed to show a simple login screen without social logins etc.
-        // The prompt=login parameter is needed to always force the user to login again, even if the user is still
-        // technically logged in on Auth0.
-        $params = [
-            'locale' => 'nl',
-            'ui_type' => 'minimal',
-            'prompt' => 'login',
-        ];
-
         // The Auth0 SDK sets a Location header and then exits, so we do not need to return a Response object.
-        $this->auth0->login(null, null, $params);
+        $this->auth0->login(null, null, $this->loginParameters);
     }
 
     public function storeTokenAndRedirectToFrontend(): RedirectResponse


### PR DESCRIPTION
### Changed
 
- Made the Auth0 login parameters configurable. The current use case is easy switching between `ui_type=minimal` to show a minimal login screen, and `referrer=uitpas` to show the regular login screen with UiTPAS branding. It's not 100% decided yet which will be used because the regular login screen needs to be thoroughly tested in the custom-built Balie browser. It's also useful when new parameters are introduced later.
 
---

Ticket: https://jira.uitdatabank.be/browse/UPS-3269 (comment https://jira.uitdatabank.be/browse/UPS-3269#comment-107799)
