### PR TITLE
UPS-3665 Add member to counter by email

### DIFF
--- a/app/Counter/Member/MemberServiceProvider.php
+++ b/app/Counter/Member/MemberServiceProvider.php
@@ -16,6 +16,7 @@ class MemberServiceProvider implements ServiceProviderInterface
             function (Application $app) {
                 return new MemberService(
                     $app['uitpas'],
+                    $app['culturefeed_oauth_client'],
                     $app['counter_consumer_key']
                 );
             }

--- a/src/Counter/Member/MemberController.php
+++ b/src/Counter/Member/MemberController.php
@@ -65,12 +65,12 @@ class MemberController
             )
         );
 
-        $cfUser = $this->userService->getUserByEmail(
+        $this->memberService->add(
             $add->getEmailAddress()
         );
 
-        $this->memberService->add(
-            new Uid($cfUser->id)
+        $cfUser = $this->userService->getUserByEmail(
+            $add->getEmailAddress()
         );
 
         return (new JsonResponse())

--- a/src/Counter/Member/MemberService.php
+++ b/src/Counter/Member/MemberService.php
@@ -2,12 +2,28 @@
 
 namespace CultuurNet\UiTPASBeheer\Counter\Member;
 
+use CultureFeed_OAuthClient;
 use CultuurNet\UiTPASBeheer\Counter\CounterAwareUitpasService;
+use CultuurNet\UiTPASBeheer\Counter\CounterConsumerKey;
 use CultuurNet\UiTPASBeheer\User\Properties\Uid;
 use CultuurNet\UiTPASBeheer\User\UserNotFoundException;
 
 class MemberService extends CounterAwareUitpasService implements MemberServiceInterface
 {
+    /**
+     * @var CultureFeed_OAuthClient
+     */
+    private $oauthClient;
+
+    public function __construct(
+        \CultureFeed_Uitpas $uitpasService,
+        CultureFeed_OAuthClient $oauthClient,
+        CounterConsumerKey $counterConsumerKey
+    ) {
+        parent::__construct($uitpasService, $counterConsumerKey);
+        $this->oauthClient = $oauthClient;
+    }
+
     /**
      * @return Member[]
      */

--- a/src/Counter/Member/MemberService.php
+++ b/src/Counter/Member/MemberService.php
@@ -6,7 +6,7 @@ use CultureFeed_OAuthClient;
 use CultuurNet\UiTPASBeheer\Counter\CounterAwareUitpasService;
 use CultuurNet\UiTPASBeheer\Counter\CounterConsumerKey;
 use CultuurNet\UiTPASBeheer\User\Properties\Uid;
-use CultuurNet\UiTPASBeheer\User\UserNotFoundException;
+use ValueObjects\Web\EmailAddress;
 
 class MemberService extends CounterAwareUitpasService implements MemberServiceInterface
 {
@@ -56,18 +56,14 @@ class MemberService extends CounterAwareUitpasService implements MemberServiceIn
         return $members;
     }
 
-    /**
-     * @param Uid $uid
-     *
-     * @throws UserNotFoundException
-     *   When no user was found for the given email address.
-     */
-    public function add(Uid $uid)
+    public function add(EmailAddress $emailAddress)
     {
-        $this->getUitpasService()->addMemberToCounter(
-            $uid->toNative(),
-            $this->getCounterConsumerKey()
-        );
+        $data = [
+            'email' => $emailAddress->toNative(),
+            'balieConsumerKey' => $this->getCounterConsumerKey(),
+        ];
+
+        $this->oauthClient->authenticatedPost('uitpas/balie/member', $data);
     }
 
     /**

--- a/src/Counter/Member/MemberServiceInterface.php
+++ b/src/Counter/Member/MemberServiceInterface.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UiTPASBeheer\Counter\Member;
 
 use CultuurNet\UiTPASBeheer\User\Properties\Uid;
 use CultuurNet\UiTPASBeheer\User\UserNotFoundException;
+use ValueObjects\Web\EmailAddress;
 
 interface MemberServiceInterface
 {
@@ -12,13 +13,7 @@ interface MemberServiceInterface
      */
     public function all();
 
-    /**
-     * @param Uid $uid
-     *
-     * @throws UserNotFoundException
-     *   When no user was found for the given email address.
-     */
-    public function add(Uid $uid);
+    public function add(EmailAddress $emailAddress);
 
     /**
      * @param Uid $uid

--- a/test/Counter/Member/MemberControllerTest.php
+++ b/test/Counter/Member/MemberControllerTest.php
@@ -102,6 +102,10 @@ class MemberControllerTest extends \PHPUnit_Framework_TestCase
         $json = '{"email": "foo@bar.com"}';
         $request = new Request([], [], [], [], [], [], $json);
 
+        $this->memberService->expects($this->once())
+            ->method('add')
+            ->with(new EmailAddress('foo@bar.com'));
+
         $cfUser = new User();
         $cfUser->id = 'd6ec5bbf-ff7c-4ae9-a7c1-f62df05c12fb';
         $cfUser->nick = 'foo.bar';
@@ -110,10 +114,6 @@ class MemberControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getUserByEmail')
             ->with(new EmailAddress('foo@bar.com'))
             ->willReturn($cfUser);
-
-        $this->memberService->expects($this->once())
-            ->method('add')
-            ->with(new Uid('d6ec5bbf-ff7c-4ae9-a7c1-f62df05c12fb'));
 
         $response = $this->controller->add($request);
 

--- a/test/Counter/Member/MemberServiceTest.php
+++ b/test/Counter/Member/MemberServiceTest.php
@@ -6,6 +6,7 @@ use CultureFeed_OAuthClient;
 use CultuurNet\UiTPASBeheer\Counter\CounterConsumerKey;
 use CultuurNet\UiTPASBeheer\User\Properties\Uid;
 use ValueObjects\StringLiteral\StringLiteral;
+use ValueObjects\Web\EmailAddress;
 
 class MemberServiceTest extends \PHPUnit_Framework_TestCase
 {
@@ -86,13 +87,16 @@ class MemberServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function it_can_add_a_new_member_to_the_active_counter()
     {
-        $uid = new Uid('d6ec5bbf-ff7c-4ae9-a7c1-f62df05c12fb');
+        $uid = new EmailAddress('foo@example.com');
 
-        $this->uitpas->expects($this->once())
-            ->method('addMemberToCounter')
+        $this->oauthClient->expects($this->once())
+            ->method('authenticatedPost')
             ->with(
-                $uid->toNative(),
-                $this->counterConsumerKey->toNative()
+                'uitpas/balie/member',
+                [
+                    'email' => 'foo@example.com',
+                    'balieConsumerKey' => $this->counterConsumerKey->toNative(),
+                ]
             );
 
         $this->service->add($uid);

--- a/test/Counter/Member/MemberServiceTest.php
+++ b/test/Counter/Member/MemberServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UiTPASBeheer\Counter\Member;
 
+use CultureFeed_OAuthClient;
 use CultuurNet\UiTPASBeheer\Counter\CounterConsumerKey;
 use CultuurNet\UiTPASBeheer\User\Properties\Uid;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -12,6 +13,11 @@ class MemberServiceTest extends \PHPUnit_Framework_TestCase
      * @var \CultureFeed_Uitpas|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $uitpas;
+
+    /**
+     * @var CultureFeed_OAuthClient|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $oauthClient;
 
     /**
      * @var CounterConsumerKey
@@ -26,10 +32,12 @@ class MemberServiceTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->uitpas = $this->getMock(\CultureFeed_Uitpas::class);
+        $this->oauthClient = $this->getMock(CultureFeed_OAuthClient::class);
         $this->counterConsumerKey = new CounterConsumerKey('abc');
 
         $this->service = new MemberService(
             $this->uitpas,
+            $this->oauthClient,
             $this->counterConsumerKey
         );
     }


### PR DESCRIPTION
### Changed
 
- Counter members are now added by email address instead of uid. This way UiTPAS can look up the email address in UiTID v2 if the user does not exist in v1 yet and migrate it if needed. The user is now looked up by this app _after_ (s)he has been added to the counter (to return the user id in the response as was done before), so by then the user is migrated to v1 and is guaranteed to exist there.

---

Ticket: https://jira.uitdatabank.be/browse/UPS-3665

Note: I decided to just inject the HTTP client and do the API request directly instead of via a method in the CultureFeed library, so we don't need to make a new PR there and tag a release to support this functionality, since that library should only be used in projects that will be EOL soon anyway.

Tested this manually by creating a v2 account on https://profile-acc.uitid.be/nl/signup and adding the user with that email to a counter.
