### PR TITLE
UPS-3686 fix checkin start date and checkin end date

### DIFF
--- a/src/Activity/CheckinConstraint.php
+++ b/src/Activity/CheckinConstraint.php
@@ -79,8 +79,14 @@ final class CheckinConstraint implements \JsonSerializable
     {
         $data = [
             'allowed' => $this->allowed,
-            'startDate' => $this->startDate->toNativeDateTime()->format(\DateTime::RFC3339),
-            'endDate' => $this->endDate->toNativeDateTime()->format(\DateTime::RFC3339),
+            'startDate' => $this->startDate
+                ->toNativeDateTime()
+                ->setTimezone(new \DateTimeZone('Europe/Brussels'))
+                ->format(\DateTime::RFC3339),
+            'endDate' => $this->endDate
+                ->toNativeDateTime()
+                ->setTimezone(new \DateTimeZone('Europe/Brussels'))
+                ->format(\DateTime::RFC3339),
         ];
 
         if (!is_null($this->reason)) {

--- a/test/Activity/CheckinConstraintTest.php
+++ b/test/Activity/CheckinConstraintTest.php
@@ -113,8 +113,8 @@ class CheckinConstraintTest extends \PHPUnit_Framework_TestCase
         $event = new CultureFeed_Uitpas_Event_CultureEvent();
         $event->checkinAllowed = true;
 
-        // culturefeed-php converts the datetime in the XML to a timestamp using strtotime(), so we should do to copy
-        // the actual behavior.
+        // culturefeed-php converts the datetime in the XML to a timestamp using strtotime(), so we should do it too to
+        // copy the actual behavior.
         $event->checkinStartDate = strtotime('2021-10-31T23:00:00+01:00');
         $event->checkinEndDate = strtotime('2022-01-30T23:59:59+01:00');
 

--- a/test/Activity/CheckinConstraintTest.php
+++ b/test/Activity/CheckinConstraintTest.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UiTPASBeheer\Activity;
 
+use CultureFeed_Uitpas_Event_CultureEvent;
 use CultuurNet\UiTPASBeheer\JsonAssertionTrait;
 use ValueObjects\DateTime\Date;
 use ValueObjects\DateTime\DateTime;
@@ -102,5 +103,32 @@ class CheckinConstraintTest extends \PHPUnit_Framework_TestCase
             json_encode($this->checkinConstraint),
             'Activity/data/checkin_constraint.json'
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_correctly_converts_checkinStartDate_and_checkinEndDate(): void
+    {
+        $event = new CultureFeed_Uitpas_Event_CultureEvent();
+        $event->checkinAllowed = true;
+
+        // culturefeed-php converts the datetime in the XML to a timestamp using strtotime(), so we should do to copy
+        // the actual behavior.
+        $event->checkinStartDate = strtotime('2021-10-31T23:00:00+01:00');
+        $event->checkinEndDate = strtotime('2022-01-30T23:59:59+01:00');
+
+        // After converting the datetime in the XML to a unix timestamp, then a ValueObjects\DateTime\DateTime object,
+        // then a native \DateTime object, and then finally a string in a JSON property, it should be the same as before
+        // in the XML.
+        $expected = [
+            'allowed' => true,
+            'startDate' => '2021-10-31T23:00:00+01:00',
+            'endDate' => '2022-01-30T23:59:59+01:00',
+        ];
+
+        $actual = CheckinConstraint::fromCultureFeedUitpasEvent($event)->jsonSerialize();
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/test/Activity/data/activities.json
+++ b/test/Activity/data/activities.json
@@ -11,8 +11,8 @@
       "when": "test event 1 date",
       "checkinConstraint": {
         "allowed": false,
-        "startDate": "2015-09-01T09:00:00+00:00",
-        "endDate": "2016-03-01T16:00:00+00:00",
+        "startDate": "2015-09-01T11:00:00+02:00",
+        "endDate": "2016-03-01T17:00:00+01:00",
         "reason": "INVALID_DATE_TIME"
       },
       "free": true,
@@ -25,8 +25,8 @@
       "when": "test event 2 date",
       "checkinConstraint": {
         "allowed": false,
-        "startDate": "2015-09-01T09:00:00+00:00",
-        "endDate": "2016-03-01T16:00:00+00:00",
+        "startDate": "2015-09-01T11:00:00+02:00",
+        "endDate": "2016-03-01T17:00:00+01:00",
         "reason": "INVALID_DATE_TIME"
       },
       "free": true,

--- a/test/Activity/data/activity-updated.json
+++ b/test/Activity/data/activity-updated.json
@@ -3,8 +3,8 @@
   "title": "test event 1",
   "checkinConstraint": {
     "allowed": false,
-    "startDate": "2015-09-01T09:00:00+00:00",
-    "endDate": "2016-03-01T16:00:00+00:00",
+    "startDate": "2015-09-01T11:00:00+02:00",
+    "endDate": "2016-03-01T17:00:00+01:00",
     "reason": "INVALID_DATE_TIME"
   },
   "points": 1,

--- a/test/Activity/data/activity.json
+++ b/test/Activity/data/activity.json
@@ -5,8 +5,8 @@
   "when": "yesterday",
   "checkinConstraint": {
     "allowed": false,
-    "startDate": "2015-09-01T09:00:00+00:00",
-    "endDate": "2016-03-01T16:00:00+00:00",
+    "startDate": "2015-09-01T11:00:00+02:00",
+    "endDate": "2016-03-01T17:00:00+01:00",
     "reason": "INVALID_DATE_TIME"
   },
   "points": 1,

--- a/test/Activity/data/checkin_constraint.json
+++ b/test/Activity/data/checkin_constraint.json
@@ -1,6 +1,6 @@
 {
   "allowed": false,
-  "startDate": "2015-09-01T09:00:00+00:00",
-  "endDate": "2016-03-01T16:00:00+00:00",
+  "startDate": "2015-09-01T11:00:00+02:00",
+  "endDate": "2016-03-01T17:00:00+01:00",
   "reason": "INVALID_DATE_TIME"
 }


### PR DESCRIPTION
### Fixed
 
- Fixed incorrect conversion of `checkinStartDate` and `checkinEndDate` in UiTPAS event XML to `startDate` and `endDate` in `checkinConstraint` JSON due to the timezone being dropped
 
---

Ticket: https://jira.uitdatabank.be/browse/UPS-3686
