### PR TITLE
UPS-3713 Fix destination parameter for login not working

### DIFF
--- a/src/Auth/AuthController.php
+++ b/src/Auth/AuthController.php
@@ -95,7 +95,16 @@ final class AuthController
         // before.
         $this->userSessionService->setMinimalUserInfo($uitIDv1Token);
 
-        return new RedirectResponse($this->redirectUrlAfterLogin);
+        // Redirect either to the app URL in the config file, or the destination query parameter that was given in the
+        // login request and stored in the session in redirectToLoginService().
+        $destination = $this->redirectUrlAfterLogin;
+        $destinationInSession = $this->session->get('auth_destination', null);
+        if ($destinationInSession) {
+            $destination = $destinationInSession;
+            $this->session->remove('auth_destination');
+        }
+
+        return new RedirectResponse($destination);
     }
 
     public function getToken(): JsonResponse

--- a/src/Auth/AuthController.php
+++ b/src/Auth/AuthController.php
@@ -8,6 +8,7 @@ use Auth0\SDK\Auth0;
 use CultuurNet\UiTIDProvider\User\UserSessionService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 final class AuthController
@@ -58,7 +59,7 @@ final class AuthController
         $this->redirectUrlAfterLogin = $redirectUrlAfterLogin;
     }
 
-    public function redirectToLoginService(): void
+    public function redirectToLoginService(Request $request): void
     {
         // Clear any persistent Auth0 data that lingers in some edge cases even if the user is considered to be logged
         // out by the Balie app. For example, when a user with only a v2 id logs in they get an error because they need
@@ -66,6 +67,17 @@ final class AuthController
         // the Auth0 SDK. So calling this in the logout functionality of our own app won't fix this either. The safest
         // way is to call it right before redirecting to the Auth0 login.
         $this->auth0->logout();
+
+        // If a destination query parameter is given, save it in the session to redirect back to later after the user
+        // has logged in on Auth0 and has been redirected back to the Silex backend. But only if the destination starts
+        // with the configured base URL that would normally be redirected to!
+        // For example configured app URL is https://balie.uitpas.be/app/ and the destination is
+        // https://balie.uitpas.be/app/activities, that is okay. But if the destination is e.g. https://www.google.com
+        // ignore it to prevent phishing attacks.
+        $destination = $request->query->get('destination', null);
+        if ($destination !== null && strpos($destination, $this->redirectUrlAfterLogin) === 0) {
+            $this->session->set('auth_destination', $destination);
+        }
 
         // The Auth0 SDK sets a Location header and then exits, so we do not need to return a Response object.
         $this->auth0->login(null, null, $this->loginParameters);


### PR DESCRIPTION
### Fixed
 
- Fixed `destination` parameter not working when logging in. (Was not re-implemented when we switched from UiTID v1 to UiTID v2)
 
---

Ticket: https://jira.uitdatabank.be/browse/UPS-3713
