### PR TITLE
Removed 7.2, 7.3 from pipeline, because if we upgrade, it will be to PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.1', '7.2', '7.3', '7.4']
+                php-versions: ['7.1', '7.4']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION

 
### Changed
 Removed 7.2, 7.3 from pipeline, because if we upgrade, it will be to PHP 7.4

