### PR TITLE
UPS-5145 Keycloak fix UiTiDv1 fallback

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS are automatically assigned as possible reviewers to new PRs.
+
+# Global owners (also need to be duplicated in later rules)
+* @LucWollants @JonasVHG @simon-debruijn @grubolsch
+
+# Jenkins / deployment owners
+Gemfile* @willaerk @paulherbosch
+Jenkinsfile @willaerk @paulherbosch
+Rakefile @willaerk @paulherbosch
+lib/ @willaerk @paulherbosch

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -94,8 +94,9 @@ $app->register(new Silex\Provider\UrlGeneratorServiceProvider());
 /**
  * Authentication services
  */
-$app['auth0_enabled'] = isset($app['config']['auth0']['enable']) && $app['config']['auth0']['enable'] === true;
-if ($app['auth0_enabled']) {
+$app['external_auth_enabled'] = (isset($app['config']['auth0']['enable']) && $app['config']['auth0']['enable'] === true) || (isset($app['config']['keycloak']['enable']) && $app['config']['keycloak']['enable'] === true);
+
+if ($app['external_auth_enabled']) {
     $app->register(new AuthServiceProvider());
 } else {
     $app->register(new CultuurNet\UiTIDProvider\Auth\AuthServiceProvider());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -94,13 +94,8 @@ $app->register(new Silex\Provider\UrlGeneratorServiceProvider());
 /**
  * Authentication services
  */
-$app['external_auth_enabled'] = (isset($app['config']['auth0']['enable']) && $app['config']['auth0']['enable'] === true) || (isset($app['config']['keycloak']['enable']) && $app['config']['keycloak']['enable'] === true);
 
-if ($app['external_auth_enabled']) {
-    $app->register(new AuthServiceProvider());
-} else {
-    $app->register(new CultuurNet\UiTIDProvider\Auth\AuthServiceProvider());
-}
+$app->register(new AuthServiceProvider());
 
 /**
  * UiTID User services.

--- a/bootstrap/logging.php
+++ b/bootstrap/logging.php
@@ -30,7 +30,7 @@ $app['third_party_api_logger_factory'] = $app->protect(
     }
 );
 
-if (!$app['auth0_enabled']) {
+if (!$app['external_auth_enabled']) {
     $app['uitid_auth_service'] = $app->share(
         $app->extend(
             'uitid_auth_service',

--- a/bootstrap/logging.php
+++ b/bootstrap/logging.php
@@ -7,7 +7,7 @@
 
 const MESSAGE_FORMAT = ">>>>>>>>\n{request}\n<<<<<<<<\n{response}\nTime: {total_time}s\n--------\n{curl_stderr}";
 
-$app['third_party_api_log'] = $app->share(
+$app['third_party_api_log'] = $app::share(
     function () {
         $handler = new \Monolog\Handler\StreamHandler(
             __DIR__ . '/../log/third_party_api.log'
@@ -19,7 +19,7 @@ $app['third_party_api_log'] = $app->share(
     }
 );
 
-$app['third_party_api_logger_factory'] = $app->protect(
+$app['third_party_api_logger_factory'] = $app::protect(
     function ($name) use ($app) {
         $logger = new Monolog\Logger($name);
         $logger->pushHandler(
@@ -30,31 +30,10 @@ $app['third_party_api_logger_factory'] = $app->protect(
     }
 );
 
-if (!$app['external_auth_enabled']) {
-    $app['uitid_auth_service'] = $app->share(
-        $app->extend(
-            'uitid_auth_service',
-            function (\CultuurNet\Auth\Guzzle\Service $service, \Silex\Application $app) {
-                /** @var \Psr\Log\LoggerInterface $logger */
-                $logger = $app['third_party_api_logger_factory']('cultuurnet_auth');
-
-                $logPlugin = new \Guzzle\Plugin\Log\LogPlugin(
-                    new \Guzzle\Log\PsrLogAdapter($logger),
-                    MESSAGE_FORMAT
-                );
-
-                $service->addSubscriber($logPlugin);
-
-                return $service;
-            }
-        )
-    );
-}
-
 /**
  * Enable logging on the guzzle client of Culturefeed.
  */
-$app['culturefeed_http_client_guzzle'] = $app->share(
+$app['culturefeed_http_client_guzzle'] = $app::share(
     $app->extend(
         'culturefeed_http_client_guzzle',
         function (\Guzzle\Http\Client $service, \Silex\Application $app) {
@@ -73,7 +52,7 @@ $app['culturefeed_http_client_guzzle'] = $app->share(
     )
 );
 
-$app['expense_report_api'] = $app->share(
+$app['expense_report_api'] = $app::share(
     $app->extend(
         'expense_report_api',
         function (\CultuurNet\UiTPASBeheer\ExpenseReport\ExpenseReportApiService $service, \Silex\Application $app) {
@@ -92,7 +71,7 @@ $app['expense_report_api'] = $app->share(
     )
 );
 
-$app['datavalidation_guzzle_client'] = $app->share(
+$app['datavalidation_guzzle_client'] = $app::share(
     $app->extend(
         'datavalidation_guzzle_client',
         function (\Guzzle\Http\Client $service, \Silex\Application $app) {

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.4-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends git zip unzip libicu-dev libtidy-dev zlib1g-dev libpng-dev libzip-dev
 
@@ -37,6 +37,7 @@ RUN npm run bower -- install &
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/web
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+RUN echo "LimitRequestFieldSize 32766" >> /etc/apache2/conf-available/security.conf
 
 RUN pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug
 COPY xdebug.ini $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini

--- a/web/index.php
+++ b/web/index.php
@@ -47,7 +47,7 @@ $app->register(new \CultuurNet\UiTPASBeheer\JsonPostDataServiceProvider());
 /**
  * API callbacks for authentication.
  */
-if ($app['auth0_enabled']) {
+if ($app['external_auth_enabled']) {
     $app->mount('culturefeed/oauth', new AuthControllerProvider());
 } else {
     $app->mount('culturefeed/oauth', new \CultuurNet\UiTIDProvider\Auth\AuthControllerProvider());

--- a/web/index.php
+++ b/web/index.php
@@ -47,11 +47,7 @@ $app->register(new \CultuurNet\UiTPASBeheer\JsonPostDataServiceProvider());
 /**
  * API callbacks for authentication.
  */
-if ($app['external_auth_enabled']) {
-    $app->mount('culturefeed/oauth', new AuthControllerProvider());
-} else {
-    $app->mount('culturefeed/oauth', new \CultuurNet\UiTIDProvider\Auth\AuthControllerProvider());
-}
+$app->mount('culturefeed/oauth', new AuthControllerProvider());
 
 /**
  * API callbacks for UiTID user data and methods.


### PR DESCRIPTION
### Added
 
- Add header in docker file for big Keycloak tokens.
 
### Changed
 
- In docker update php version to PHP 7.4
- **Important:** If you currently set Keycloak enabled on true and auth0 on false, it rolls back to UiTiDv1 as fallback, which is not what you want, you want keycloak... I added a fix for this.
 
---

Ticket: https://jira.uitdatabank.be/browse/UPS-5145 